### PR TITLE
Revert minimum sdk and change "marquee" namespace to "app".

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,6 @@ android {
 	compileSdkVersion 30
 	buildToolsVersion "29.0.2"
 	defaultConfig {
-		minSdkVersion 19
 		targetSdkVersion 30
 		versionCode 1
 		versionName(version)

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -5,6 +5,6 @@
           android:versionName="1.0">
 
     <uses-sdk
-            android:minSdkVersion="19"
+            android:minSdkVersion="7"
             android:targetSdkVersion="30"/>
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
           android:versionName="1.1">
 
     <uses-sdk
-        android:minSdkVersion="19"
+        android:minSdkVersion="7"
         android:targetSdkVersion="30"/>
 
     <application

--- a/sample/src/main/res/layout/main.xml
+++ b/sample/src/main/res/layout/main.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:marquee="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
 
     <TextView
         android:text="First MarqueeView"
@@ -45,9 +45,9 @@
         android:id="@+id/marqueeView150"
         android:layout_width="150dp"
         android:layout_height="wrap_content"
-        marquee:animationSpeed="5"
-        marquee:animationDelay="1000"
-        marquee:autoStart="true"
+        app:animationSpeed="5"
+        app:animationDelay="1000"
+        app:autoStart="true"
         >
 
         <TextView
@@ -84,9 +84,9 @@
         android:id="@+id/marqueeView3"
         android:layout_width="150dp"
         android:layout_height="wrap_content"
-        marquee:animationSpeed="10"
-        marquee:animationDelay="700"
-        marquee:autoStart="false"
+        app:animationSpeed="10"
+        app:animationDelay="700"
+        app:autoStart="false"
         >
 
         <TextView


### PR DESCRIPTION
@BenHenning I reverted to the initial minimum sdk since after changing this for some reason i was not being able to successfully resolve the namespace after integrating with Oppia. I thought this might have caused the issue since the other changes couldn't have. I have also chamged the "marquee" namespace to "app" in sample project to promote consistency. PTAL and merge to official fork.